### PR TITLE
chore: Remove Python 3.11 upper bound

### DIFF
--- a/.github/workflows/cloudcoverage.yml
+++ b/.github/workflows/cloudcoverage.yml
@@ -15,7 +15,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: CloudTestCoverage - Python ${{ matrix.python }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: TestCoverage - Python ${{ matrix.python }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,9 @@ install_requires =
     scipy>=1.4.1
     sympy>=1.5,<=1.9
     orquestra-quantum
-    amazon-braket-sdk<=1.25.2
-    boto3<=1.24.38
-
-
-
+# Previously, we have had some incompatibilities with braket
+# This is a cautionary upper bound for a known good version
+    amazon-braket-sdk<=1.57.2
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8,!=3.9.7,<3.11
+python_requires = >=3.9,!=3.9.7
 
 install_requires =
     numpy>=1.20

--- a/tests/orquestra/braket/simulator_test.py
+++ b/tests/orquestra/braket/simulator_test.py
@@ -33,7 +33,11 @@ def test_braket_local_wf_simulator_fulfills_circuit_runner_contracts(contract):
     assert contract(simulator)
 
 
-@pytest.mark.parametrize("contract", simulator_gate_compatibility_contracts())
+@pytest.mark.local
+# Braket doesn't support the RH gate, so we're excluding it from the test set.
+@pytest.mark.parametrize(
+    "contract", simulator_gate_compatibility_contracts(gates_to_exclude=["RH"])
+)
 def test_braket_simulator_uses_correct_gate_definitionscontract(contract):
     simulator = braket_local_simulator()
     assert contract(simulator)


### PR DESCRIPTION
## Description

In order to allow Python versions newer than 3.10 we need to remove the upper bound.

This PR:
- allows Orquestra Braket to work on 3.11 and later
- Fixes tests that were not running
- Updates Braket


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
